### PR TITLE
file and line number support in options array.

### DIFF
--- a/lib/FirePHPCore/FirePHP.class.php
+++ b/lib/FirePHPCore/FirePHP.class.php
@@ -994,6 +994,12 @@ class FirePHP {
         }
         
         if ($this->options['includeLineNumbers']) {
+			// if the file and line numbers are set in options array
+			if (isset($options['file']) && isset($options['line']))  {
+				$meta['file'] = $options['file'];
+				$meta['line'] = $options['line'];
+			}
+
             if (!isset($meta['file']) || !isset($meta['line'])) {
     
                 $trace = debug_backtrace();

--- a/lib/FirePHPCore/FirePHP.class.php4
+++ b/lib/FirePHPCore/FirePHP.class.php4
@@ -621,6 +621,12 @@ class FirePHP {
     }
     
     if($this->options['includeLineNumbers']) {
+      // if the file and line numbers are set in options array
+      if (isset($options['file']) && isset($options['line']))  {
+        $meta['file'] = $options['file'];
+        $meta['line'] = $options['line'];
+      }
+
       if(!isset($meta['file']) || !isset($meta['line'])) {
 
         $trace = debug_backtrace();


### PR DESCRIPTION
Recently I was using FirePHP in a project where I had to create a kind of wrapper function around firephp. All the error and custom notices were handled by a custom error handler which in turn sent those to FirePHP. 

FirePHP was showing line and file number of the custom error handler function, so I forked and added support in the options array so the custom file and line number can be passed.

I am not sure if this will be a useful feature for other people.
