### PR TITLE
Allow for Ignored Files and Classes when File and Line Number is Shown

### DIFF
--- a/lib/FirePHPCore/FirePHP.class.php
+++ b/lib/FirePHPCore/FirePHP.class.php
@@ -239,6 +239,21 @@ class FirePHP {
     protected $logToInsightConsole = null;
 
     /**
+     * Ignored classes
+     *
+     * @var array
+     */
+    protected $ignoredClasses = array(__CLASS__);
+    
+    /**
+     * Ignored files
+     *
+     * @var array
+     */
+    protected $ignoredFiles   = array(__FILE__);
+
+
+    /**
      * When the object gets serialized only include specific object members.
      * 
      * @return array
@@ -362,6 +377,26 @@ class FirePHP {
     public function getOptions()
     {
         return $this->options;
+    }
+
+    /**
+    * Add Class to Ignore List
+    * @param string $className
+    * @return FirePHP
+    */
+    public function ignoreClass($className) {
+        if(!array_search($className, $this->ignoredClasses)) $this->ignoredClasses[] = $className;
+        return $this;
+    }
+
+    /**
+    * Add File to Ignore List
+    * @param string $className
+    * @return FirePHP
+    */
+    public function ignoreFile($fileName) {
+        if(!array_search($fileName, $this->ignoredFiles)) $this->ignoredFiles[] = $fileName;
+        return $this;
     }
 
     /**
@@ -791,6 +826,12 @@ class FirePHP {
             $trace = debug_backtrace();
             if (!$trace) return false;
             for ($i = 0; $i < sizeof($trace); $i++) {
+                if(isset($trace[$i]['class']) && in_array($trace[$i]['class'], $this->ignoredClasses)) {
+                    continue;
+                }
+                if(isset($trace[$i]['file']) && in_array($trace[$i]['file'], $this->ignoredFiles)) {
+                    continue;
+                }
                 if (isset($trace[$i]['class'])) {
                     if ($trace[$i]['class'] == 'FirePHP' || $trace[$i]['class'] == 'FB') {
                         continue;
@@ -935,7 +976,12 @@ class FirePHP {
             $trace = debug_backtrace();
             if (!$trace) return false;
             for ($i = 0; $i < sizeof($trace); $i++) {
-    
+                if(isset($trace[$i]['class']) && in_array($trace[$i]['class'], $this->ignoredClasses)) {
+                    continue;
+                }
+                if(isset($trace[$i]['file']) && in_array($trace[$i]['file'], $this->ignoredFiles)) {
+                    continue;
+                }
                 if (isset($trace[$i]['class'])
                    && isset($trace[$i]['file'])
                    && ($trace[$i]['class'] == 'FirePHP'
@@ -998,7 +1044,12 @@ class FirePHP {
     
                 $trace = debug_backtrace();
                 for ($i = 0; $trace && $i < sizeof($trace); $i++) {
-          
+                    if(isset($trace[$i]['class']) && in_array($trace[$i]['class'], $this->ignoredClasses)) {
+                        continue;
+                    }
+                    if(isset($trace[$i]['file']) && in_array($trace[$i]['file'], $this->ignoredFiles)) {
+                        continue;
+                    }
                     if (isset($trace[$i]['class'])
                        && isset($trace[$i]['file'])
                        && ($trace[$i]['class'] == 'FirePHP'


### PR DESCRIPTION
Like hameedullah, I too have a wrapper of sorts which allows me to call more than just FirePHP for logging and error handling. The problem with that is the file that would show would be from my wrapper or it's wrapper. I've changed the FirePHP PHP 5 class to allow for files and classes be excluded. This could be helpful in other situations as well, such as if you have a database wrapper and want to get that actual script and line that called the query command instead of the database class.

Usage:

$this->firephp = \FirePHP::getInstance(true);
$this->firephp
    ->ignoreClass('ClassName')
    ->ignoreFile('/path/to/my/file.php');

Maybe this can get merged, or at the very least help someone else who needs the same functionality.
