### PR TITLE
Add Composer support to FirePHP Core

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,26 @@
+{
+    "name": "firephp/firephp-core",
+    "description": "Traditional FirePHPCore library for sending PHP variables to the browser.",
+    "type": "library",
+    "homepage": "https://github.com/firephp/firephp-core",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Christoph Dorn",
+            "email": "christoph@christophdorn.com",
+            "homepage": "christophdorn.com"
+        }
+    ],
+    "support": {
+        "forum": "http://groups.google.com/group/firephp-dev",
+        "issues": "https://github.com/firephp/firephp-core/issues",
+        "source": "https://github.com/firephp/firephp-core"
+    },
+    "autoload": {
+        "classmap": [
+            "lib/FirePHPCore/FirePHP.class.php",
+            "lib/FirePHPCore/fb.php"
+        ]
+    }
+}
+


### PR DESCRIPTION
[Composer](http://getcomposer.org/) is a dependency management system for PHP packages. This pull request adds Composer support to FirePHP Core. Having this means that a project that depends on FirePHP could put this in their composer.json file to have it automatically download and autoload FirePHP:

```
{
    "require": {
        "firephp/firephp-core": "*"
    }
}
```

When installing the client application, you would run "php composer.phar install", and it would download FirePHP-Core, and have the FirePHP class autoloaded so that the files would be included automatically when the FirePHP class is used. Any package on http://packagist.org could then also depict a dependency on the package if needed.

Thanks a lot!
