### PR TITLE
Fix homepage url

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         {
             "name": "Christoph Dorn",
             "email": "christoph@christophdorn.com",
-            "homepage": "christophdorn.com"
+            "homepage": "http://christophdorn.com"
         }
     ],
     "support": {


### PR DESCRIPTION
To facilitate package metadata consumption URLs and all are now validated a bit more strictly, so the package definition became invalid a while back.
