### PR TITLE
Add maxCombinedSize option to truncate logs if HTTP header gets big

### DIFF
--- a/tests/TestHelper.php
+++ b/tests/TestHelper.php
@@ -28,20 +28,16 @@ class FirePHP_Test_Class extends FirePHP {
     private $_headers = array();    
 
 
-    public function _getHeaders() {
+    public function getAllResponseHeaders() {
         return $this->_headers;
     }
-    public function _clearHeaders() {
-        $this->_headers = array();
+
+    public function getHeadersSentSize() {
+        return parent::getHeadersSentSize();
     }
 
-
-    // ######################
-    // # Subclassed Methods #
-    // ######################   
-
-    protected function setHeader($Name, $Value) {
-        $this->_headers[$Name] = $Value;
+    public function setResponseHeader($name, $value) {
+        $this->_headers[$name] = $name . ': ' . $value;
     }
     
     protected function headersSent(&$Filename, &$Linenum) {


### PR DESCRIPTION
The new option can be set programmatically via $firePhp->setOption()
or via an HTTP header in the request (typically sent by the browser
extension).

The limit is expressed in bytes. So if the overall limit for all
headers for your browser is 256kb, then send the header
"X-FirePHP-MaxCombinedSize: 262144"

This fixes #10