### PR TITLE
PHPUnit: now auto-runs tests without folder argument

### DIFF
--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -1,2 +1,0 @@
-<phpunit bootstrap="TestHelper.php">
-</phpunit>

--- a/tests/phpunit.xml.dist
+++ b/tests/phpunit.xml.dist
@@ -1,0 +1,9 @@
+<phpunit bootstrap="TestHelper.php">
+
+  <testsuites>
+    <testsuite>
+      <directory suffix=".php">./</directory>
+    </testsuite>
+  </testsuites>
+
+</phpunit>


### PR DESCRIPTION
Will now automatically run in tests folder, by just typing ‘phpunit’
