### PR TITLE
Workaround for PHP bug #2801

### DIFF
--- a/lib/FirePHPCore/FirePHP.class.php
+++ b/lib/FirePHPCore/FirePHP.class.php
@@ -1294,7 +1294,8 @@ class FirePHP {
 
         $return = array();
     
-        if (is_resource($object)) {
+        //#2801 is_resource reports false for closed resources https://bugs.php.net/bug.php?id=28016
+        if (is_resource($object) || gettype($object) === "unknown type") {
     
             return '** ' . (string) $object . ' **';
     


### PR DESCRIPTION
is_resource reports false for closed resources https://bugs.php.net/bug.php?id=28016
still reproducible in php 5.4.30, encodeObject tries to is_utf8 a resource and generates an error that resource was given to mb_detect_encoding instead of string
