### PR TITLE
Update FirePHP.class.php

### DIFF
--- a/lib/FirePHPCore/FirePHP.class.php
+++ b/lib/FirePHPCore/FirePHP.class.php
@@ -482,7 +482,7 @@ class FirePHP {
      *
      * @return mixed Returns a string containing the previously defined error handler (if any)
      */
-    public function registerErrorHandler($throwErrorExceptions = false)
+    public function registerErrorHandler($throwErrorExceptions = false, $use_error_reporting = false)
     {
         //NOTE: The following errors will not be caught by this error handler:
         //      E_ERROR, E_PARSE, E_CORE_ERROR,
@@ -491,7 +491,7 @@ class FirePHP {
 
         $this->throwErrorExceptions = $throwErrorExceptions;
 
-        return set_error_handler(array($this, 'errorHandler'));
+        return $use_error_reporting?set_error_handler(array($this,'errorHandler'),error_reporting()):set_error_handler(array($this,'errorHandler'));
     }
 
     /**


### PR DESCRIPTION
adding error_reporting() as 2nd parameter (error_levels), when registering the errorhandler, results in not having to have a call to errorHandler() whenever PHP throwing an error, but only for those, that are activated.

E_WARNINGs and E_NOTICEs can sum up very fast in hundreds to thousands of unnecessary calls to errorHandler(), just to have errorHandler() to decide not to throw an exception.

Drawback of this version: if you change error_reporting after registerErrorHandler(), you have to call registerErrorHandler again, in order to get the new error_reporting into count.
For backward compatibility, a new parameter ($use_error_reporting) is introduced, defaulting to false, providing the functions old behaviour